### PR TITLE
Implement cookie-based sessions and update client auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To ensure the project runs smoothly and no errors are encounter follow the next 
 - Navigate to the project directory
   `cd portfolio-generator`
 - Install all the dependencies
-  `npm install `
+  `npm install`
 - Make sure all the dependencies are up to date
   `npm update`
 - To run the server use `npm run start:server`
@@ -71,17 +71,26 @@ The PortfolioBuilder project follows a typical MERN (MongoDB, Express, React, No
 - Backend Processing: The backend processes the requests, interacts with MongoDB to perform CRUD operations, and sends - responses back to the frontend.
 - State Management: The frontend updates its state based on the responses from the backend.
 
-#### API Endpoints
+#### Authentication & API Endpoints
 
-- User Registration: POST /register
-- User Login: POST /login
-- Fetch User Data: GET /user/:id
-- Fetch User Skills: GET /user/:id/skills
-- Add Project: POST /projects
-- Edit Project: PUT /projects/:userId/:projectId
-- Delete Project: DELETE /users/:userId/projects/:projectId
-- Add Skills: POST /user/:id/skills
-- Fetch Projects: GET /projects/:userId
+The application issues short-lived, cookie-backed sessions. The frontend must send authenticated requests with
+`withCredentials: true` so the browser includes the httpOnly `accessToken` and `refreshToken` cookies.
+
+- `POST /register` — creates a user, stores an encrypted session, and returns the shareable portfolio token.
+- `POST /login` — rotates the portfolio token, refreshes the session cookies, and returns the authenticated user.
+- `POST /refresh` — swaps an expired access token for a new pair of session cookies.
+- `POST /logout` — clears the session cookies and revokes the stored session identifiers.
+- `GET /me` — returns the authenticated user (used to guard dashboard and project routes).
+- `POST /portfolio/token/rotate` — issues a new shareable portfolio token without altering the active session.
+- `GET /portfolio/:token` — publicly renders a portfolio for the supplied share token.
+- `GET /projects` — retrieves the signed-in user’s projects.
+- `POST /projects` — creates a project for the signed-in user.
+- `PUT /projects/:projectId` — updates one of the signed-in user’s projects.
+- `DELETE /projects/:projectId` — removes one of the signed-in user’s projects.
+- `GET /skills` — fetches the signed-in user’s skill lists.
+- `PUT /skills` — replaces the signed-in user’s skill lists.
+- `GET /user/:token` — publicly fetches a user profile by portfolio token.
+- `GET /user/:token/skills` — publicly fetches skill lists by portfolio token.
 
 ### Environment Setup
 
@@ -89,11 +98,18 @@ To set up different environments (development and production):
 
 #### Development:
 
-- Configure your .env file for local development.
+- Configure your `.env` file for local development.
+- Required variable:
+  - `MONGODB_URI` — connection string for your MongoDB instance.
+- Optional variables:
+  - `PORT` — overrides the default API port (3001).
+  - `ACCESS_TOKEN_EXPIRATION_MINUTES` — minutes before an access token expires (default 15).
+  - `REFRESH_TOKEN_EXPIRATION_DAYS` — days before a refresh token expires (default 7).
 - Use local MongoDB or a development MongoDB Atlas cluster.
-  Production:
 
-- Configure your environment variables on Heroku and Netlify.
+#### Production:
+
+- Configure the same environment variables on Heroku (backend) and Netlify (frontend).
 - Use MongoDB Atlas for a production database.
 
 ### Deployment Details
@@ -146,3 +162,9 @@ This project is set to be open source in future development steps. Here are some
 - Documentation: Comprehensive documentation for developers and end-users.
 
 Due to time constraints allocated for my dissertation, these features are not possible to be completed before the deadline. However, once the open source license is established, we welcome contributions and look forward to collaborative development to make this project robust and widely useful.
+
+### Client-side session handling
+
+- The React client configures Axios with `withCredentials: true` for authenticated requests so the browser automatically forwards the httpOnly session cookies.
+- Sensitive identifiers are kept out of `localStorage`; the `UserProvider` bootstraps user state by calling `GET /me` and exposes helpers to clear the session on `401` responses.
+- Dashboard and project routes should gate access by awaiting `/me` and redirecting unauthenticated users to `/login`.

--- a/src/UserContext.tsx
+++ b/src/UserContext.tsx
@@ -1,12 +1,11 @@
-import axios from "axios";
 import React, { useCallback, useEffect, useState } from "react";
 import LoadingBars from "./frontend/components/LoadingBars/LoadingBars";
+import { getCurrentUser } from "./api";
 
 export interface User {
-  _id: string;
+  id: string;
   fullName: string;
   email: string;
-  password: string;
   jobTitle: string;
   profileImage: string;
 }
@@ -14,6 +13,11 @@ export interface User {
 export interface UserContextProps {
   user: User | null;
   setUser: React.Dispatch<React.SetStateAction<User | null>>;
+  portfolioToken: string | null;
+  setPortfolioToken: React.Dispatch<React.SetStateAction<string | null>>;
+  refreshUser: () => Promise<void>;
+  clearSession: () => void;
+  loading: boolean;
 }
 
 export const UserContext = React.createContext<UserContextProps | undefined>(
@@ -24,29 +28,43 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [user, setUser] = useState<User | null>(null);
+  const [portfolioToken, setPortfolioToken] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const API_BASE_URL = process.env.REACT_APP_API_URL;
+  const clearSession = useCallback(() => {
+    setUser(null);
+    setPortfolioToken(null);
+  }, []);
 
   const fetchUser = useCallback(async () => {
-    const token = localStorage.getItem("portfolioToken");
-    if (token) {
+    try {
+      const response = await getCurrentUser();
+      setUser(response.user);
+      setPortfolioToken(response.portfolioToken ?? null);
+    } catch (error) {
+      clearSession();
+      throw error;
+    }
+  }, [clearSession]);
+
+  const refreshUser = useCallback(async () => {
+    await fetchUser();
+  }, [fetchUser]);
+
+  useEffect(() => {
+    const loadUser = async () => {
       try {
-        const response = await axios.get(`${API_BASE_URL}/user/${token}`);
-        setUser(response.data.user);
+        await fetchUser();
       } catch (error) {
-        console.log(error);
+        // Ignore errors during initial load; user will remain signed out
       } finally {
         setLoading(false);
       }
-    } else {
-      setLoading(false);
-    }
-  }, [API_BASE_URL]);
+    };
 
-  useEffect(() => {
-    fetchUser();
+    loadUser();
   }, [fetchUser]);
+
   if (loading) {
     const bars = [
       { width: "300px", delay: "0s" },
@@ -57,7 +75,17 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
   }
 
   return (
-    <UserContext.Provider value={{ user, setUser }}>
+    <UserContext.Provider
+      value={{
+        user,
+        setUser,
+        portfolioToken,
+        setPortfolioToken,
+        refreshUser,
+        clearSession,
+        loading,
+      }}
+    >
       {children}
     </UserContext.Provider>
   );

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -8,164 +8,217 @@ import {
   registerUser,
   createProject,
   editProject,
-  addSkills,
+  updateSkills,
   editUserDetails,
+  getCurrentUser,
+  refreshSession,
+  logoutUser,
+  rotatePortfolioToken,
+  fetchPublicProjects,
 } from "./api";
-import { mock } from "node:test";
 
 jest.mock("axios");
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-describe("Testing the api functions", () => {
-  afterEach(() => {
+const API_BASE_URL = process.env.REACT_APP_API_URL;
+
+describe("API helpers", () => {
+  beforeEach(() => {
     jest.clearAllMocks();
   });
-  it("should login a user successfully", async () => {
-    const mockData = {
-      token: "mockToken",
-      user: { id: "1", name: "John Doe" },
-    };
 
-    mockedAxios.post.mockResolvedValueOnce({ status: 200, data: mockData });
+  it("loginUser posts credentials with cookies", async () => {
+    const mockData = { user: { id: "1" }, portfolioToken: "token" };
+    mockedAxios.post.mockResolvedValueOnce({ data: mockData });
 
-    const result = await loginUser("test@email.com", "password");
+    const result = await loginUser("test@email.com", "Password123!");
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      `${API_BASE_URL}/login`,
+      { email: "test@email.com", password: "Password123!" },
+      expect.objectContaining({ withCredentials: true })
+    );
     expect(result).toEqual(mockData);
-    expect(localStorage.getItem("portfolioToken")).toBe("mockToken");
-  });
-  it("should throw an error when login fails", async () => {
-    const mockError = new Error("Login fail");
-
-    mockedAxios.post.mockRejectedValueOnce(mockError);
-    await expect(
-      loginUser("test@email.com", "wrongpassword")
-    ).rejects.toThrow();
-    expect(localStorage.getItem("portfolioToken")).toBeNull();
   });
 
-  it("fetches projects successfully", async () => {
-    const data = { projects: [{ id: 1, name: "Project 1" }] };
-    (axios.get as jest.Mock).mockResolvedValue({ data });
+  it("registerUser uploads form data", async () => {
+    const mockForm = new FormData();
+    const mockResponse = {
+      data: { user: { id: "1" }, portfolioToken: "token" },
+    };
+    mockedAxios.post.mockResolvedValueOnce(mockResponse);
 
-    const result = await fetchProjects("mockToken");
-    expect(result).toEqual(data);
+    const result = await registerUser(mockForm);
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      `${API_BASE_URL}/register`,
+      mockForm,
+      expect.objectContaining({ withCredentials: true })
+    );
+    expect(result).toEqual(mockResponse.data);
   });
 
-  it("throws an error when the request fails", async () => {
-    const error = new Error("Network error");
-    (axios.get as jest.Mock).mockRejectedValue(error);
+  it("fetchProjects requests authenticated projects", async () => {
+    const projects = [{ id: "1", name: "Project" }];
+    mockedAxios.get.mockResolvedValueOnce({ data: projects });
 
-    await expect(fetchProjects("mockToken")).rejects.toThrow("Network error");
+    const result = await fetchProjects();
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${API_BASE_URL}/projects`,
+      expect.objectContaining({ withCredentials: true })
+    );
+    expect(result).toEqual(projects);
   });
 
-  it("fetches skills successfully", async () => {
-    const data = { skills: ["JavaScript", "React"] };
-    mockedAxios.get.mockResolvedValue({ data });
-    const result = await fetchSkills("mockToken");
-    expect(result).toEqual(data);
+  it("fetchSkills requests authenticated skills", async () => {
+    const skills = { techSkills: ["JS"], softSkills: [] };
+    mockedAxios.get.mockResolvedValueOnce({ data: skills });
+
+    const result = await fetchSkills();
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${API_BASE_URL}/skills`,
+      expect.objectContaining({ withCredentials: true })
+    );
+    expect(result).toEqual(skills);
   });
-  it("throws an error when the request fails", async () => {
-    const error = new Error("Network error");
-    mockedAxios.get.mockRejectedValue(error);
-    await expect(fetchSkills("mockToken")).rejects.toThrow("Network error");
-  });
-  it("deletes a project", async () => {
-    mockedAxios.delete.mockResolvedValue({});
-    await deleteProject("1", "1");
+
+  it("deleteProject sends delete request", async () => {
+    mockedAxios.delete.mockResolvedValueOnce({ status: 200 });
+
+    await deleteProject("1");
+
     expect(mockedAxios.delete).toHaveBeenCalledWith(
-      `${process.env.REACT_APP_API_URL}/users/1/projects/1`
+      `${API_BASE_URL}/projects/1`,
+      expect.objectContaining({ withCredentials: true })
     );
   });
-  it("register a user", async () => {
-    const mockData = new FormData();
-    mockData.append("name", "John Doe");
-    mockData.append("email", "test@email.com");
-    mockData.append("password", "password");
-    mockData.append("profileImage", "imageUrl");
-    const response = { data: { token: "mockToken" } };
-    mockedAxios.post.mockResolvedValue(response);
-    const result = await registerUser(mockData);
+
+  it("createProject posts form data", async () => {
+    const formData = new FormData();
+    const mockProject = { id: "1", name: "Project" };
+    mockedAxios.post.mockResolvedValueOnce({ data: mockProject });
+
+    const result = await createProject(formData);
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      `${API_BASE_URL}/projects`,
+      formData,
+      expect.objectContaining({ withCredentials: true })
+    );
+    expect(result).toEqual(mockProject);
+  });
+
+  it("editProject updates a project", async () => {
+    const formData = new FormData();
+    const mockProject = { id: "2", name: "Updated" };
+    mockedAxios.put.mockResolvedValueOnce({ data: mockProject });
+
+    const result = await editProject("2", formData);
+
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${API_BASE_URL}/projects/2`,
+      formData,
+      expect.objectContaining({ withCredentials: true })
+    );
+    expect(result).toEqual(mockProject);
+  });
+
+  it("updateSkills sends skills payload", async () => {
+    const skills = { techSkills: ["JS"], softSkills: ["Teamwork"] };
+    mockedAxios.put.mockResolvedValueOnce({ data: skills });
+
+    const result = await updateSkills(skills);
+
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${API_BASE_URL}/skills`,
+      { skills },
+      expect.objectContaining({ withCredentials: true })
+    );
+    expect(result).toEqual(skills);
+  });
+
+  it("editUserDetails updates the user profile", async () => {
+    const payload = { fullName: "Jane", email: "jane@test.com", jobTitle: "Dev" };
+    const updated = { user: { id: "1", ...payload, profileImage: "" } };
+    mockedAxios.put.mockResolvedValueOnce({ data: updated });
+
+    const result = await editUserDetails(payload);
+
+    expect(mockedAxios.put).toHaveBeenCalledWith(
+      `${API_BASE_URL}/user`,
+      payload,
+      expect.objectContaining({ withCredentials: true })
+    );
+    expect(result).toEqual(updated);
+  });
+
+  it("getCurrentUser returns the current session", async () => {
+    const current = { user: { id: "1" }, portfolioToken: "token" };
+    mockedAxios.get.mockResolvedValueOnce({ data: current });
+
+    const result = await getCurrentUser();
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${API_BASE_URL}/me`,
+      expect.objectContaining({ withCredentials: true })
+    );
+    expect(result).toEqual(current);
+  });
+
+  it("refreshSession posts to refresh endpoint", async () => {
+    const refreshed = { user: { id: "1" } };
+    mockedAxios.post.mockResolvedValueOnce({ data: refreshed });
+
+    const result = await refreshSession();
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      `${API_BASE_URL}/refresh`,
+      {},
+      expect.objectContaining({ withCredentials: true })
+    );
+    expect(result).toEqual(refreshed);
+  });
+
+  it("logoutUser posts to logout endpoint", async () => {
+    const response = { message: "Logged out" };
+    mockedAxios.post.mockResolvedValueOnce({ data: response });
+
+    const result = await logoutUser();
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      `${API_BASE_URL}/logout`,
+      {},
+      expect.objectContaining({ withCredentials: true })
+    );
     expect(result).toEqual(response);
   });
 
-  it("creates a project", async () => {
-    const mockData = new FormData();
-    mockData.append("name", "Project 1");
-    mockData.append("description", "Description");
-    mockData.append("projectImage", "imageUrl");
-    const response = { data: { id: 1, name: "Project 1" } };
-    mockedAxios.post.mockResolvedValue(response);
-    const result = await createProject(mockData);
-    expect(result).toEqual(response.data);
-  });
-  it("throws an error when the request fails", async () => {
-    const error = new Error("Network error");
-    mockedAxios.post.mockRejectedValue(error);
-    await expect(createProject(new FormData())).rejects.toThrow(
-      "Network error"
-    );
-  });
-  it("edits a project", async () => {
-    const mockData = new FormData();
-    mockData.append("name", "Project 1");
-    mockData.append("description", "Description");
-    mockData.append("projectImage", "imageUrl");
-    const response = { data: [{ _id: "1", name: "Project 1" }] };
-    const userId = "1";
-    const projectId = "1";
-    const API_BASE_URL = process.env.REACT_APP_API_URL;
-    mockedAxios.put.mockResolvedValue(response);
-    const result = await editProject(userId, projectId, mockData);
-    expect(result).toEqual(
-      response.data.find((project) => project._id === projectId)
-    );
-    expect(mockedAxios.put).toHaveBeenCalledWith(
-      `${API_BASE_URL}/projects/${userId}/${projectId}`,
-      mockData
-    );
+  it("rotatePortfolioToken posts to rotation endpoint", async () => {
+    const payload = { portfolioToken: "new-token" };
+    mockedAxios.post.mockResolvedValueOnce({ data: payload });
 
-    // Check if axios.put was called only once
-    expect(mockedAxios.put).toHaveBeenCalledTimes(1);
-  });
-  it("throws an error when the request fails", async () => {
-    const error = new Error("Network error");
-    mockedAxios.put.mockRejectedValue(error);
-    await expect(editProject("1", "1", new FormData())).rejects.toThrow(
-      "Network error"
-    );
-  });
-  it("adds skills", async () => {
-    const mockData = {
-      techSkills: ["JavaScript", "React"],
-      softSkills: ["Team Player"],
-    };
-    const response = { data: { techSkills: ["JavaScript", "React"] } };
-    mockedAxios.post.mockResolvedValue(response);
-    const result = await addSkills("1", mockData);
-    expect(result).toEqual(response.data);
-  });
-  it("throws an error when the request fails", async () => {
-    const error = new Error("Network error");
-    mockedAxios.post.mockRejectedValue(error);
-    await expect(
-      addSkills("1", {
-        techSkills: ["JavaScript", "React"],
-        softSkills: ["Team Player"],
-      })
-    ).rejects.toThrow("Network error");
-  });
-  it("edits user details", async () => {
-    const mockData = {
-      fullName: "John Doe",
-      email: "test@email.com",
-      jobTitle: "Software engineer",
-    };
+    const result = await rotatePortfolioToken();
 
-    const response = {
-      data: { fullName: "John Doe", email: "test@email.com" },
-    };
-    mockedAxios.put.mockResolvedValue(response);
-    const result = await editUserDetails("1", mockData, "1");
-    expect(result).toEqual(response.data);
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      `${API_BASE_URL}/portfolio/token/rotate`,
+      {},
+      expect.objectContaining({ withCredentials: true })
+    );
+    expect(result).toEqual(payload);
+  });
+
+  it("fetchPublicProjects retrieves public projects", async () => {
+    const projects = [{ id: "1" }];
+    mockedAxios.get.mockResolvedValueOnce({ data: projects });
+
+    const result = await fetchPublicProjects("token");
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      `${API_BASE_URL}/projects/token`
+    );
+    expect(result).toEqual(projects);
   });
 });

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,122 +1,153 @@
 import axios from "axios";
-import { Project } from "./frontend/components/UserDashboard/UserDashboard";
 
 const API_BASE_URL = process.env.REACT_APP_API_URL;
 
-export const fetchProjects = async (portfolioToken: string) => {
-  const projectsResponse = await axios.get(
-    `${API_BASE_URL}/projects/${portfolioToken}`
-  );
-  return projectsResponse.data;
+const withCredentialsConfig = { withCredentials: true };
+
+export const fetchProjects = async () => {
+  const response = await axios.get(`${API_BASE_URL}/projects`, withCredentialsConfig);
+  return response.data;
 };
 
-export const fetchSkills = async (portfolioToken: string) => {
-  const skillsResponse = await axios.get(
-    `${API_BASE_URL}/user/${portfolioToken}/skills`
-  );
-  return skillsResponse.data;
+export const fetchSkills = async () => {
+  const response = await axios.get(`${API_BASE_URL}/skills`, withCredentialsConfig);
+  return response.data;
 };
 
-export const deleteProject = async (userId: string, projectId: string) => {
-  await axios.delete(`${API_BASE_URL}/users/${userId}/projects/${projectId}`);
+export const deleteProject = async (projectId: string) => {
+  await axios.delete(`${API_BASE_URL}/projects/${projectId}`, withCredentialsConfig);
 };
 
 export const loginUser = async (email: string, password: string) => {
-  try {
-    const response = await axios.post(
-      `${API_BASE_URL}/login`,
-      { email, password },
-      {
-        headers: {
-          "Content-Type": "application/json",
-        },
-        withCredentials: true,
-      }
-    );
-    if (response.status === 200) {
-      localStorage.setItem("portfolioToken", response.data.token);
+  const response = await axios.post(
+    `${API_BASE_URL}/login`,
+    { email, password },
+    {
+      ...withCredentialsConfig,
+      headers: {
+        "Content-Type": "application/json",
+      },
     }
-    return response.data;
-  } catch (error: any) {
-    localStorage.removeItem("portfolioToken");
-    console.error("Error during login:", error);
-    throw error;
-  }
+  );
+  return response.data;
 };
 
 export const registerUser = async (formData: FormData) => {
   const response = await axios.post(`${API_BASE_URL}/register`, formData, {
+    ...withCredentialsConfig,
     headers: {
       "Content-Type": "multipart/form-data",
     },
   });
-  localStorage.setItem("portfolioToken", response.data.token);
-  return response;
+  return response.data;
 };
 
 export const createProject = async (formData: FormData) => {
-  const apiUrl = `${API_BASE_URL}/projects`;
-
-  try {
-    const response = await axios.post(apiUrl, formData, {
-      headers: {
-        "Content-Type": "multipart/form-data",
-      },
-    });
-    return response.data;
-  } catch (error: any) {
-    console.error(
-      "Error creating project:",
-      error.response ? error.response.data : error.message
-    );
-    throw error;
-  }
+  const response = await axios.post(`${API_BASE_URL}/projects`, formData, {
+    ...withCredentialsConfig,
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+  return response.data;
 };
 
 export const editProject = async (
-  userId: string,
   projectId: string | undefined,
   formData: FormData
 ) => {
   const response = await axios.put(
-    `${API_BASE_URL}/projects/${userId}/${projectId}`,
-    formData
+    `${API_BASE_URL}/projects/${projectId}`,
+    formData,
+    {
+      ...withCredentialsConfig,
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    }
   );
-  const updatedProject = response.data.find(
-    (project: Project) => project._id === projectId
-  );
-
-  return updatedProject;
+  return response.data;
 };
 
-export const addSkills = async (
-  portfolioToken: string,
-  skills: { techSkills: string[]; softSkills: string[] }
-) => {
-  const response = await axios.post(
-    `${API_BASE_URL}/user/${portfolioToken}/skills`,
-    { skills }
+export const updateSkills = async (skills: {
+  techSkills: string[];
+  softSkills: string[];
+}) => {
+  const response = await axios.put(
+    `${API_BASE_URL}/skills`,
+    { skills },
+    {
+      ...withCredentialsConfig,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
   );
   return response.data;
 };
 
 export const editUserDetails = async (
-  portfolioToken: string,
-  formData: { fullName: string; email: string; jobTitle: string },
-  userId: string
+  formData: { fullName: string; email: string; jobTitle: string }
 ) => {
-  const config = {
+  const response = await axios.put(`${API_BASE_URL}/user`, formData, {
+    ...withCredentialsConfig,
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${portfolioToken}`,
     },
-  };
+  });
+  return response.data;
+};
 
-  const response = await axios.put(
-    `${API_BASE_URL}/user/${userId}`,
-    JSON.stringify(formData),
-    config
+export const getCurrentUser = async () => {
+  const response = await axios.get(`${API_BASE_URL}/me`, withCredentialsConfig);
+  return response.data;
+};
+
+export const refreshSession = async () => {
+  const response = await axios.post(
+    `${API_BASE_URL}/refresh`,
+    {},
+    {
+      ...withCredentialsConfig,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
   );
+  return response.data;
+};
 
+export const logoutUser = async () => {
+  const response = await axios.post(
+    `${API_BASE_URL}/logout`,
+    {},
+    {
+      ...withCredentialsConfig,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+  return response.data;
+};
+
+export const rotatePortfolioToken = async () => {
+  const response = await axios.post(
+    `${API_BASE_URL}/portfolio/token/rotate`,
+    {},
+    {
+      ...withCredentialsConfig,
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+  return response.data;
+};
+
+export const fetchPublicProjects = async (portfolioToken: string) => {
+  const response = await axios.get(
+    `${API_BASE_URL}/projects/${portfolioToken}`
+  );
   return response.data;
 };

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -1,15 +1,20 @@
 import mongoose from "mongoose";
 import express from "express";
-const app = express();
 import multer from "multer";
-const upload = multer({ dest: "uploads/" });
 import cors from "cors";
 import bcrypt from "bcrypt";
-app.use("/uploads", express.static("uploads"));
 import dotenv from "dotenv";
+import crypto from "crypto";
 import { v4 as uuidv4 } from "uuid";
+
 dotenv.config();
+
+const app = express();
+const upload = multer({ dest: "uploads/" });
+
+app.use("/uploads", express.static("uploads"));
 app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 
 const allowedOrigins =
   process.env.NODE_ENV === "production"
@@ -22,28 +27,161 @@ app.use(
     credentials: true,
   })
 );
-const UserSchema = new mongoose.Schema({
-  fullName: String,
-  email: String,
-  password: String,
-  jobTitle: String,
-  profileImage: String,
-  projects: [
-    {
-      name: String,
-      description: String,
-      image: String,
-      link: String,
-    },
-  ],
-  skills: {
-    softSkills: [String],
-    techSkills: [String],
-  },
-  portfolioToken: { type: String, unique: true },
+
+const isProduction = process.env.NODE_ENV === "production";
+const ACCESS_TOKEN_EXPIRATION_MINUTES = parseInt(
+  process.env.ACCESS_TOKEN_EXPIRATION_MINUTES || "15",
+  10
+);
+const REFRESH_TOKEN_EXPIRATION_DAYS = parseInt(
+  process.env.REFRESH_TOKEN_EXPIRATION_DAYS || "7",
+  10
+);
+const ACCESS_TOKEN_MAX_AGE = ACCESS_TOKEN_EXPIRATION_MINUTES * 60 * 1000;
+const REFRESH_TOKEN_MAX_AGE = REFRESH_TOKEN_EXPIRATION_DAYS * 24 * 60 * 60 * 1000;
+
+const cookieOptions = (maxAge) => ({
+  httpOnly: true,
+  secure: isProduction,
+  sameSite: isProduction ? "none" : "lax",
+  maxAge,
 });
 
+const clearCookieOptions = {
+  httpOnly: true,
+  secure: isProduction,
+  sameSite: isProduction ? "none" : "lax",
+};
+
+const passwordStrengthRegex =
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$/;
+
+const UserSchema = new mongoose.Schema(
+  {
+    fullName: String,
+    email: { type: String, unique: true },
+    password: String,
+    jobTitle: String,
+    profileImage: String,
+    projects: {
+      type: [
+        {
+          name: String,
+          description: String,
+          image: String,
+          link: String,
+        },
+      ],
+      default: [],
+    },
+    skills: {
+      softSkills: { type: [String], default: [] },
+      techSkills: { type: [String], default: [] },
+    },
+    portfolioToken: { type: String, unique: true },
+    accessTokenId: { type: String },
+    accessTokenHash: { type: String },
+    accessTokenExpiresAt: { type: Date },
+    refreshTokenId: { type: String },
+    refreshTokenHash: { type: String },
+    refreshTokenExpiresAt: { type: Date },
+  },
+  { timestamps: true }
+);
+
 const User = mongoose.model("User", UserSchema);
+
+const sanitizeUser = (user) => ({
+  id: user._id.toString(),
+  fullName: user.fullName,
+  email: user.email,
+  jobTitle: user.jobTitle,
+  profileImage: user.profileImage,
+});
+
+const isStrongPassword = (password) => passwordStrengthRegex.test(password);
+
+const parseCookies = (req) => {
+  const cookieHeader = req.headers?.cookie;
+  if (!cookieHeader) {
+    return {};
+  }
+  return cookieHeader.split(";").reduce((acc, pair) => {
+    const [key, value] = pair.trim().split("=");
+    if (key && value) {
+      acc[key] = decodeURIComponent(value);
+    }
+    return acc;
+  }, {});
+};
+
+const generateTokenParts = () => {
+  const id = crypto.randomBytes(8).toString("hex");
+  const secret = crypto.randomBytes(32).toString("hex");
+  return { id, secret, value: `${id}.${secret}` };
+};
+
+const setAuthCookies = (res, accessTokenValue, refreshTokenValue) => {
+  res.cookie("accessToken", accessTokenValue, cookieOptions(ACCESS_TOKEN_MAX_AGE));
+  res.cookie("refreshToken", refreshTokenValue, cookieOptions(REFRESH_TOKEN_MAX_AGE));
+};
+
+const clearAuthCookies = (res) => {
+  res.clearCookie("accessToken", clearCookieOptions);
+  res.clearCookie("refreshToken", clearCookieOptions);
+};
+
+const issueSession = async (user, res) => {
+  const accessToken = generateTokenParts();
+  const refreshToken = generateTokenParts();
+
+  user.accessTokenId = accessToken.id;
+  user.accessTokenHash = await bcrypt.hash(accessToken.secret, 10);
+  user.accessTokenExpiresAt = new Date(Date.now() + ACCESS_TOKEN_MAX_AGE);
+
+  user.refreshTokenId = refreshToken.id;
+  user.refreshTokenHash = await bcrypt.hash(refreshToken.secret, 10);
+  user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE);
+
+  await user.save();
+
+  setAuthCookies(res, accessToken.value, refreshToken.value);
+};
+
+const authenticate = async (req, res, next) => {
+  const cookies = parseCookies(req);
+  const token = cookies.accessToken;
+  if (!token) {
+    return res.status(401).send({ message: "Unauthorized" });
+  }
+
+  const [tokenId, tokenSecret] = token.split(".");
+  if (!tokenId || !tokenSecret) {
+    return res.status(401).send({ message: "Unauthorized" });
+  }
+
+  try {
+    const user = await User.findOne({ accessTokenId: tokenId });
+    if (
+      !user ||
+      !user.accessTokenHash ||
+      !user.accessTokenExpiresAt ||
+      user.accessTokenExpiresAt < new Date()
+    ) {
+      return res.status(401).send({ message: "Unauthorized" });
+    }
+
+    const isValid = await bcrypt.compare(tokenSecret, user.accessTokenHash);
+    if (!isValid) {
+      return res.status(401).send({ message: "Unauthorized" });
+    }
+
+    req.user = user;
+    next();
+  } catch (error) {
+    return res.status(401).send({ message: "Unauthorized" });
+  }
+};
 
 app.get("/portfolio/:token", async (req, res) => {
   const token = req.params.token;
@@ -70,65 +208,302 @@ app.get("/portfolio/:token", async (req, res) => {
 
 app.post("/register", upload.single("profileImage"), async (req, res) => {
   try {
-    const existingUser = await User.findOne({ email: req.body.email });
+    const { fullName, email, password, jobTitle } = req.body;
+
+    if (!isStrongPassword(password)) {
+      return res.status(400).send({
+        message:
+          "Password must be at least 8 characters long and include uppercase, lowercase, number, and special character.",
+      });
+    }
+
+    const existingUser = await User.findOne({ email });
     if (existingUser) {
       return res.status(400).send({ message: "User already registered." });
     }
 
-    const hashedPassword = await bcrypt.hash(req.body.password, 10);
-    const token = uuidv4();
+    const hashedPassword = await bcrypt.hash(password, 10);
+
     const user = new User({
-      ...req.body,
+      fullName,
+      email,
       password: hashedPassword,
+      jobTitle,
       profileImage: req.file ? req.file.path : null,
-      portfolioToken: token,
+      portfolioToken: uuidv4(),
     });
 
-    const result = await user.save();
+    await issueSession(user, res);
+
     res.status(201).send({
-      user: {
-        id: result._id,
-        fullName: result.fullName,
-        email: result.email,
-        jobTitle: result.jobTitle,
-        profileImage: result.profileImage,
-      },
-      token,
+      user: sanitizeUser(user),
+      portfolioToken: user.portfolioToken,
     });
   } catch (err) {
     res.status(500).send({ message: err.message });
   }
 });
+
 app.post("/login", async (req, res) => {
   try {
     const { email, password } = req.body;
     const user = await User.findOne({ email });
 
     if (!user) {
-      return res.status(404).send({ message: "Invalid email or password" });
+      return res.status(401).send({ message: "Invalid email or password" });
     }
 
     const isMatch = await bcrypt.compare(password, user.password);
     if (!isMatch) {
-      return res.status(404).send({ message: "Invalid email or password" });
+      return res.status(401).send({ message: "Invalid email or password" });
     }
 
-    // Generate a token if it doesn't exist
-    if (!user.portfolioToken) {
-      user.portfolioToken = uuidv4();
-      await user.save();
-    }
+    user.portfolioToken = uuidv4();
+    await issueSession(user, res);
 
     res.status(200).send({
-      user: {
-        id: user.id,
-        fullName: user.fullName,
-        email: user.email,
-        jobTitle: user.jobTitle,
-        profileImage: user.profileImage,
-      },
-      token: user.portfolioToken,
+      user: sanitizeUser(user),
+      portfolioToken: user.portfolioToken,
     });
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+});
+
+app.post("/refresh", async (req, res) => {
+  const cookies = parseCookies(req);
+  const token = cookies.refreshToken;
+  if (!token) {
+    return res.status(401).send({ message: "Unauthorized" });
+  }
+
+  const [tokenId, tokenSecret] = token.split(".");
+  if (!tokenId || !tokenSecret) {
+    clearAuthCookies(res);
+    return res.status(401).send({ message: "Unauthorized" });
+  }
+
+  try {
+    const user = await User.findOne({ refreshTokenId: tokenId });
+
+    if (
+      !user ||
+      !user.refreshTokenHash ||
+      !user.refreshTokenExpiresAt ||
+      user.refreshTokenExpiresAt < new Date()
+    ) {
+      clearAuthCookies(res);
+      return res.status(401).send({ message: "Unauthorized" });
+    }
+
+    const isValid = await bcrypt.compare(tokenSecret, user.refreshTokenHash);
+    if (!isValid) {
+      clearAuthCookies(res);
+      return res.status(401).send({ message: "Unauthorized" });
+    }
+
+    await issueSession(user, res);
+
+    res.status(200).send({
+      user: sanitizeUser(user),
+      portfolioToken: user.portfolioToken,
+    });
+  } catch (error) {
+    clearAuthCookies(res);
+    res.status(401).send({ message: "Unauthorized" });
+  }
+});
+
+app.post("/logout", async (req, res) => {
+  const cookies = parseCookies(req);
+  const accessToken = cookies.accessToken;
+  const refreshToken = cookies.refreshToken;
+
+  try {
+    if (refreshToken) {
+      const [refreshId] = refreshToken.split(".");
+      const user = await User.findOne({ refreshTokenId: refreshId });
+      if (user) {
+        user.refreshTokenId = undefined;
+        user.refreshTokenHash = undefined;
+        user.refreshTokenExpiresAt = undefined;
+        user.accessTokenId = undefined;
+        user.accessTokenHash = undefined;
+        user.accessTokenExpiresAt = undefined;
+        await user.save();
+      }
+    } else if (accessToken) {
+      const [accessId] = accessToken.split(".");
+      const user = await User.findOne({ accessTokenId: accessId });
+      if (user) {
+        user.accessTokenId = undefined;
+        user.accessTokenHash = undefined;
+        user.accessTokenExpiresAt = undefined;
+        await user.save();
+      }
+    }
+  } catch (error) {
+    console.error("Error clearing session", error);
+  }
+
+  clearAuthCookies(res);
+  res.status(200).send({ message: "Logged out" });
+});
+
+app.get("/me", authenticate, (req, res) => {
+  res.status(200).send({
+    user: sanitizeUser(req.user),
+    portfolioToken: req.user.portfolioToken,
+  });
+});
+
+app.post("/portfolio/token/rotate", authenticate, async (req, res) => {
+  try {
+    req.user.portfolioToken = uuidv4();
+    await req.user.save();
+    res.status(200).send({ portfolioToken: req.user.portfolioToken });
+  } catch (error) {
+    res.status(500).send({ message: error.message });
+  }
+});
+
+app.get("/projects", authenticate, (req, res) => {
+  res.status(200).send(req.user.projects || []);
+});
+
+app.post("/projects", authenticate, upload.single("image"), async (req, res) => {
+  const { name, description, link } = req.body;
+  const image = req.file ? req.file.path : null;
+
+  try {
+    if (!Array.isArray(req.user.projects)) {
+      req.user.projects = [];
+    }
+
+    req.user.projects.push({ name, description, image, link });
+    await req.user.save();
+    const createdProject = req.user.projects[req.user.projects.length - 1];
+
+    res.status(201).send({
+      id: createdProject._id.toString(),
+      name: createdProject.name,
+      description: createdProject.description,
+      image: createdProject.image,
+      link: createdProject.link,
+    });
+  } catch (error) {
+    res.status(500).send({ message: error.message });
+  }
+});
+
+app.put(
+  "/projects/:projectId",
+  authenticate,
+  upload.single("image"),
+  async (req, res) => {
+    const { name, description, link } = req.body;
+    const projectId = req.params.projectId;
+
+    try {
+      const project = req.user.projects.find(
+        (proj) => proj._id.toString() === projectId
+      );
+
+      if (!project) {
+        return res.status(404).send({ message: "Project not found" });
+      }
+
+      project.name = name ?? project.name;
+      project.description = description ?? project.description;
+      project.link = link ?? project.link;
+      if (req.file) {
+        project.image = req.file.path;
+      }
+
+      await req.user.save();
+
+      res.status(200).send({
+        id: project._id.toString(),
+        name: project.name,
+        description: project.description,
+        image: project.image,
+        link: project.link,
+      });
+    } catch (error) {
+      res.status(500).send({ message: error.message });
+    }
+  }
+);
+
+app.delete("/projects/:projectId", authenticate, async (req, res) => {
+  try {
+    const projectIndex = req.user.projects.findIndex(
+      (project) => project._id.toString() === req.params.projectId
+    );
+
+    if (projectIndex === -1) {
+      return res.status(404).send({ message: "Project not found" });
+    }
+
+    req.user.projects.splice(projectIndex, 1);
+    await req.user.save();
+
+    res.status(200).send({ message: "Project deleted successfully" });
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+});
+
+app.get("/skills", authenticate, (req, res) => {
+  res.status(200).send(req.user.skills || { softSkills: [], techSkills: [] });
+});
+
+app.put("/skills", authenticate, async (req, res) => {
+  const { skills } = req.body;
+  if (!skills) {
+    return res.status(400).send({ message: "Skills payload is required" });
+  }
+
+  try {
+    req.user.skills.softSkills = skills.softSkills || [];
+    req.user.skills.techSkills = skills.techSkills || [];
+    await req.user.save();
+    res.status(200).send(req.user.skills);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+});
+
+app.get("/projects/:token", async (req, res) => {
+  const { token } = req.params;
+  try {
+    const user = await User.findOne({ portfolioToken: token });
+    if (!user) {
+      return res.status(404).send({ message: "User not found" });
+    }
+    res.status(200).send(user.projects);
+  } catch (err) {
+    res.status(500).send({ message: err.message });
+  }
+});
+
+app.put("/user", authenticate, async (req, res) => {
+  const { fullName, email, jobTitle } = req.body;
+
+  try {
+    if (email && email !== req.user.email) {
+      const existingUser = await User.findOne({ email });
+      if (existingUser && existingUser._id.toString() !== req.user._id.toString()) {
+        return res.status(400).send({ message: "Email already in use" });
+      }
+    }
+
+    req.user.fullName = fullName ?? req.user.fullName;
+    req.user.email = email ?? req.user.email;
+    req.user.jobTitle = jobTitle ?? req.user.jobTitle;
+    await req.user.save();
+
+    res.status(200).send({ user: sanitizeUser(req.user) });
   } catch (err) {
     res.status(500).send({ message: err.message });
   }
@@ -167,149 +542,10 @@ app.get("/user/:token/skills", async (req, res) => {
   }
 });
 
-app.post("/projects", upload.single("image"), (req, res) => {
-  const { userId, name, description, link } = req.body;
-  const image = req.file ? req.file.path : null;
-  User.findById(userId).then((user) => {
-    if (!user) {
-      return res.status(404).send({ message: "User not found" });
-    }
-    const newProject = { name, description, image, link };
-    user.projects.push(newProject);
-    user
-      .save()
-      .then((result) => {
-        const createdProject = result.projects.find(
-          (project) =>
-            project.name === newProject.name &&
-            project.description === newProject.description
-        );
-        res.status(201).send({
-          id: createdProject._id.toString(),
-          name: createdProject.name,
-          description: createdProject.description,
-          image: createdProject.image,
-          link: createdProject.link,
-        });
-      })
-      .catch((err) => {
-        res.status(500).send({ message: err.message });
-      });
-  });
-});
-app.post("/user/:token/skills", async (req, res) => {
-  const { skills } = req.body;
-  const { token } = req.params;
-  try {
-    const user = await User.findOne({ portfolioToken: token });
-    if (!user) {
-      return res.status(404).send({ message: "User not found" });
-    }
-    user.skills.softSkills = skills.softSkills;
-    user.skills.techSkills = skills.techSkills;
-    await user.save();
-    res.status(201).send(user.skills);
-  } catch (err) {
-    res.status(500).send({ message: err.message });
-  }
-});
-
-app.get("/projects/:token", async (req, res) => {
-  const { token } = req.params;
-  try {
-    const user = await User.findOne({ portfolioToken: token });
-    if (!user) {
-      return res.status(404).send({ message: "User not found" });
-    }
-    res.status(200).send(user.projects);
-  } catch (err) {
-    res.status(500).send({ message: err.message });
-  }
-});
-
-app.put("/projects/:userId/:projectId", upload.single("image"), (req, res) => {
-  const { name, description, link } = req.body;
-  const image = req.file ? req.file.path : null;
-  User.findById(req.params.userId)
-    .then((user) => {
-      if (!user) {
-        return res.status(404).send({ message: "User not found" });
-      }
-      const project = user.projects.find(
-        (project) => project._id.toString() === req.params.projectId
-      );
-      project.name = name;
-      project.description = description;
-      project.image = image;
-      project.link = link;
-      user
-        .save()
-        .then((result) => {
-          res.status(200).send(result.projects);
-        })
-        .catch((err) => {
-          res.status(500).send({ message: err.message });
-        });
-    })
-    .catch((err) => {
-      res.status(500).send({ message: err.message });
-    });
-});
-
-app.delete("/users/:userId/projects/:projectId", async (req, res) => {
-  try {
-    const user = await User.findById(req.params.userId);
-    if (!user) {
-      return res.status(404).send({ message: "User not found" });
-    }
-
-    const projectIndex = user.projects.findIndex(
-      (project) => project._id.toString() === req.params.projectId
-    );
-    if (projectIndex === -1) {
-      return res.status(404).send({ message: "Project not found" });
-    }
-
-    user.projects.splice(projectIndex, 1);
-    await user.save();
-
-    res.status(200).send({ message: "Project deleted successfully" });
-  } catch (err) {
-    res.status(500).send({ message: err.message });
-  }
-});
-
-app.put("/user/:userId", async (req, res) => {
-  const { fullName, email, jobTitle } = req.body;
-  const authHeader = req.headers["authorization"];
-  if (!authHeader) {
-    return res.status(403).send({ message: "No token provided" });
-  }
-  const token = authHeader.slice(7);
-
-  try {
-    const user = await User.findOne({ portfolioToken: token });
-    if (!user) {
-      return res.status(404).send({ message: "User not found" });
-    }
-    user.fullName = fullName;
-    user.email = email;
-    user.jobTitle = jobTitle;
-    const updatedUser = await user.save();
-    res.status(200).send({
-      fullName: updatedUser.fullName,
-      email: updatedUser.email,
-      jobTitle: updatedUser.jobTitle,
-    });
-  } catch (err) {
-    res.status(500).send({ message: err.message });
-  }
-});
-
 const dbURI = process.env.MONGODB_URI;
 mongoose
   .connect(dbURI)
-  .then((result) => {
+  .then(() => {
     console.log("Connected to the db");
     app.listen(process.env.PORT || 3001, () =>
       console.log("Server is running on port " + (process.env.PORT || 3001))

--- a/src/frontend/components/Login/Login.test.tsx
+++ b/src/frontend/components/Login/Login.test.tsx
@@ -29,10 +29,21 @@ jest.mock("../../../api", () => ({
 describe("Login", () => {
   it("renders", async () => {
     const mockSetUser = jest.fn();
+    const mockSetPortfolioToken = jest.fn();
     render(
       <MemoryRouter>
         <ThemeProvider theme={theme as MyTheme}>
-          <UserContext.Provider value={{ user: null, setUser: mockSetUser }}>
+          <UserContext.Provider
+            value={{
+              user: null,
+              setUser: mockSetUser,
+              portfolioToken: null,
+              setPortfolioToken: mockSetPortfolioToken,
+              refreshUser: jest.fn(),
+              clearSession: jest.fn(),
+              loading: false,
+            }}
+          >
             <Login />
           </UserContext.Provider>
         </ThemeProvider>
@@ -42,12 +53,25 @@ describe("Login", () => {
     expect(formElement).toBeInTheDocument();
   });
   it("correctly submits the form with correct arguments", async () => {
-    (loginUser as jest.Mock).mockResolvedValue({ data: { user: { id: "1" } } });
+    (loginUser as jest.Mock).mockResolvedValue({
+      user: { id: "1" },
+      portfolioToken: "token",
+    });
 
     render(
       <MemoryRouter>
         <ThemeProvider theme={theme as MyTheme}>
-          <UserContext.Provider value={{ user: null, setUser: jest.fn() }}>
+          <UserContext.Provider
+            value={{
+              user: null,
+              setUser: jest.fn(),
+              portfolioToken: null,
+              setPortfolioToken: jest.fn(),
+              refreshUser: jest.fn(),
+              clearSession: jest.fn(),
+              loading: false,
+            }}
+          >
             <Login />
           </UserContext.Provider>
         </ThemeProvider>
@@ -70,7 +94,17 @@ describe("Login", () => {
     render(
       <MemoryRouter>
         <ThemeProvider theme={theme as MyTheme}>
-          <UserContext.Provider value={{ user: null, setUser: jest.fn() }}>
+          <UserContext.Provider
+            value={{
+              user: null,
+              setUser: jest.fn(),
+              portfolioToken: null,
+              setPortfolioToken: jest.fn(),
+              refreshUser: jest.fn(),
+              clearSession: jest.fn(),
+              loading: false,
+            }}
+          >
             <Login />
           </UserContext.Provider>
         </ThemeProvider>
@@ -94,7 +128,17 @@ describe("Login", () => {
     render(
       <MemoryRouter>
         <ThemeProvider theme={theme as MyTheme}>
-          <UserContext.Provider value={{ user: null, setUser: jest.fn() }}>
+          <UserContext.Provider
+            value={{
+              user: null,
+              setUser: jest.fn(),
+              portfolioToken: null,
+              setPortfolioToken: jest.fn(),
+              refreshUser: jest.fn(),
+              clearSession: jest.fn(),
+              loading: false,
+            }}
+          >
             <Login />
           </UserContext.Provider>
         </ThemeProvider>

--- a/src/frontend/components/Login/Login.tsx
+++ b/src/frontend/components/Login/Login.tsx
@@ -10,38 +10,39 @@ import { loginUser } from "../../../api";
 
 const Login = () => {
   const navigate = useNavigate();
-  const { setUser } = useContext(UserContext) as UserContextProps;
-  const [error, setError] = useState(false);
+  const { setUser, setPortfolioToken } =
+    useContext(UserContext) as UserContextProps;
+  const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const emailInput = (e.target as HTMLFormElement).elements.namedItem(
       "email"
     ) as HTMLInputElement;
-    const email = emailInput ? emailInput.value : "";
-    const password = (e.target as HTMLFormElement).elements.namedItem(
+    const passwordInput = (e.target as HTMLFormElement).elements.namedItem(
       "password"
     ) as HTMLInputElement;
-    const passwordValue = password ? password.value : "";
+
+    const email = emailInput?.value ?? "";
+    const passwordValue = passwordInput?.value ?? "";
 
     if (email && passwordValue) {
       try {
         const data = await loginUser(email, passwordValue);
         if (data.user) {
-          const user = data.user;
-          setUser(user);
-          setError(false);
-          localStorage.setItem("userId", user.id);
+          setUser(data.user);
+          setPortfolioToken(data.portfolioToken ?? null);
+          setError(null);
           navigate("/userdashboard");
         } else {
-          setError(true);
+          setError("Invalid email or password");
         }
-      } catch (error) {
-        setError(true);
+      } catch (err: any) {
+        const message = err?.response?.data?.message || "Invalid email or password";
+        setError(message);
       }
     } else {
-      console.log("Email or password is missing");
-      setError(true);
+      setError("Email or password is missing");
     }
   };
   const theme = useTheme();
@@ -63,7 +64,7 @@ const Login = () => {
             role="alert"
             aria-live="assertive"
           >
-            Invalid email or password
+            {error}
           </div>
         )}
         <form css={style.form} onSubmit={handleSubmit} data-testid="login-form">

--- a/src/frontend/components/Logout/Logout.test.tsx
+++ b/src/frontend/components/Logout/Logout.test.tsx
@@ -1,40 +1,72 @@
 import React from "react";
 import "@testing-library/jest-dom";
-import { render, fireEvent } from "@testing-library/react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
 import Logout from "./Logout";
 import { ThemeProvider } from "@emotion/react";
 import { theme, MyTheme } from "../../../theme";
 import { MemoryRouter } from "react-router-dom";
+import { UserContext, UserContextProps } from "../../../UserContext";
+import { logoutUser } from "../../../api";
+
+jest.mock("../../../api", () => ({
+  logoutUser: jest.fn(),
+}));
 
 describe("Logout", () => {
+  const mockClearSession = jest.fn();
+  const mockContextValue = {
+    user: null,
+    setUser: jest.fn(),
+    portfolioToken: null,
+    setPortfolioToken: jest.fn(),
+    refreshUser: jest.fn(),
+    clearSession: mockClearSession,
+    loading: false,
+  } as unknown as UserContextProps;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("renders without crashing", () => {
     render(
       <MemoryRouter>
         <ThemeProvider theme={theme as MyTheme}>
-          <Logout />
+          <UserContext.Provider value={mockContextValue}>
+            <Logout />
+          </UserContext.Provider>
         </ThemeProvider>
       </MemoryRouter>
     );
   });
 
-  it("clears the localStorage", () => {
-    const localStorageSpy = jest.spyOn(window.localStorage.__proto__, "clear");
+  it("calls logoutUser and clears the session", async () => {
+    (logoutUser as jest.Mock).mockResolvedValue({ message: "Logged out" });
     const { getByRole } = render(
       <MemoryRouter>
         <ThemeProvider theme={theme as MyTheme}>
-          <Logout />
+          <UserContext.Provider value={mockContextValue}>
+            <Logout />
+          </UserContext.Provider>
         </ThemeProvider>
       </MemoryRouter>
     );
+
     fireEvent.click(getByRole("button"));
-    expect(localStorageSpy).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(logoutUser).toHaveBeenCalled();
+      expect(mockClearSession).toHaveBeenCalled();
+    });
   });
 
   it("renders a Logout button", () => {
     const { getByRole } = render(
       <MemoryRouter>
         <ThemeProvider theme={theme as MyTheme}>
-          <Logout />
+          <UserContext.Provider value={mockContextValue}>
+            <Logout />
+          </UserContext.Provider>
         </ThemeProvider>
       </MemoryRouter>
     );

--- a/src/frontend/components/Logout/Logout.tsx
+++ b/src/frontend/components/Logout/Logout.tsx
@@ -1,12 +1,22 @@
-import React from "react";
+import React, { useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import Button from "../Button/Button";
+import { logoutUser } from "../../../api";
+import { UserContext, UserContextProps } from "../../../UserContext";
 
 const Logout = () => {
   const navigate = useNavigate();
-  const handleLogout = () => {
-    localStorage.clear();
-    navigate("/");
+  const { clearSession } = useContext(UserContext) as UserContextProps;
+
+  const handleLogout = async () => {
+    try {
+      await logoutUser();
+    } catch (error) {
+      console.error("Error logging out", error);
+    } finally {
+      clearSession();
+      navigate("/login");
+    }
   };
   return (
     <Button

--- a/src/frontend/components/Modal/AddProjects.test.tsx
+++ b/src/frontend/components/Modal/AddProjects.test.tsx
@@ -7,171 +7,141 @@ import {
   render,
   fireEvent,
   cleanup,
-  within,
   waitFor,
-  act,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import axios from "axios";
-
-jest.mock("axios", () => ({
-  get: jest.fn(),
-  post: jest.fn(),
-  put: jest.fn(),
-}));
+import {
+  createProject,
+  editProject,
+} from "../../../api";
+import { UserContext, UserContextProps } from "../../../UserContext";
+import { MemoryRouter } from "react-router-dom";
 
 jest.mock("../../../api", () => ({
+  createProject: jest.fn(),
   editProject: jest.fn(),
 }));
 
-(axios.post as jest.Mock).mockResolvedValue({ data: [] });
-(axios.put as jest.Mock).mockResolvedValue({
-  data: [
-    {
-      _id: "1",
-      name: "Project Name",
-      description: "Project Description",
-      link: "Project Link",
-      image: "Project Image",
-    },
-  ],
-});
 afterEach(cleanup);
 
 describe("Add Projects Modal", () => {
-  // Mock localStorage
-  let localStorageMock: { [key: string]: string };
+  const closeModal = jest.fn();
+  const onProjectSubmission = jest.fn();
+  const clearSession = jest.fn();
+
+  const renderModal = (
+    props: Partial<React.ComponentProps<typeof AddProjectsModal>> = {}
+  ) => {
+    const contextValue = {
+      user: null,
+      setUser: jest.fn(),
+      portfolioToken: null,
+      setPortfolioToken: jest.fn(),
+      refreshUser: jest.fn(),
+      clearSession,
+      loading: false,
+    } as UserContextProps;
+
+    return render(
+      <MemoryRouter>
+        <UserContext.Provider value={contextValue}>
+          <ThemeProvider theme={theme as MyTheme}>
+            <AddProjectsModal
+              closeModal={closeModal}
+              onProjectSubmission={onProjectSubmission}
+              isOpen
+              {...props}
+            />
+          </ThemeProvider>
+        </UserContext.Provider>
+      </MemoryRouter>
+    );
+  };
+
   beforeEach(() => {
-    localStorageMock = {};
-    global.localStorage = {
-      getItem: jest.fn((key) => localStorageMock[key]),
-      setItem: jest.fn((key, value) => {
-        localStorageMock[key] = value;
-      }),
-      clear: jest.fn(() => {
-        localStorageMock = {};
-      }),
-      removeItem: jest.fn((key) => {
-        delete localStorageMock[key];
-      }),
-    } as any;
+    jest.clearAllMocks();
   });
 
-  // Mock alert
-  beforeAll(() => {
-    window.alert = jest.fn();
-  });
   it("renders without crashing", () => {
-    render(
-      <ThemeProvider theme={theme as MyTheme}>
-        <AddProjectsModal
-          closeModal={() => {}}
-          onProjectSubmission={() => {}}
-          isOpen
-        />
-      </ThemeProvider>
-    );
+    renderModal();
   });
+
   it("handles input change", () => {
-    const { getByLabelText } = render(
-      <ThemeProvider theme={theme as MyTheme}>
-        <AddProjectsModal
-          closeModal={() => {}}
-          onProjectSubmission={() => {}}
-          isOpen
-        />
-      </ThemeProvider>
-    );
+    const { getByLabelText } = renderModal();
     const nameInput = getByLabelText("Project Name") as HTMLInputElement;
     fireEvent.change(nameInput, { target: { value: "Project Name" } });
     expect(nameInput.value).toBe("Project Name");
   });
 
-  it("handles cancel  button click", async () => {
-    window.alert = jest.fn();
-    const mockCloseModal = jest.fn();
-    const { getByText } = render(
-      <ThemeProvider theme={theme as MyTheme}>
-        <AddProjectsModal
-          closeModal={mockCloseModal}
-          onProjectSubmission={() => {}}
-          isOpen
-        />
-      </ThemeProvider>
-    );
-    const cancelButton = getByText("Cancel");
-    const clickableElement = within(cancelButton).getByText("Cancel");
-
-    //Mocking the form submission
-    const form = clickableElement.closest("form");
-    const submit = form?.onsubmit;
-    if (form) {
-      form.onsubmit = function (e) {
-        e.preventDefault();
-        submit?.bind(form)(e);
-      };
-    }
-    userEvent.click(clickableElement);
-
-    await waitFor(() => {
-      expect(mockCloseModal).toHaveBeenCalled();
+  it("creates a project on submit", async () => {
+    (createProject as jest.Mock).mockResolvedValue({
+      id: "1",
+      name: "Project Name",
+      description: "Project Description",
+      image: "Project Image",
+      link: "https://project.com",
     });
-  });
-  it("updates formState on input change", () => {
-    const { getByLabelText } = render(
-      <ThemeProvider theme={theme as MyTheme}>
-        <AddProjectsModal
-          closeModal={() => {}}
-          onProjectSubmission={() => {}}
-          isOpen
-        />
-      </ThemeProvider>
-    );
-    const nameInput = getByLabelText("Project Name") as HTMLInputElement;
 
-    fireEvent.change(nameInput, { target: { value: "Project Name here" } });
-    expect(nameInput.value).toBe("Project Name here");
-
-    const linkInput = getByLabelText("Link") as HTMLInputElement;
-    fireEvent.change(linkInput, { target: { value: "www.link.com" } });
-    expect(linkInput.value).toBe("www.link.com");
-  });
-
-  it("shows an error message when trying to submit without a userId", async () => {
-    localStorage.removeItem("userId");
-    const mockLocalStorage = jest.spyOn(
-      window.localStorage.__proto__,
-      "getItem"
-    );
-    mockLocalStorage.mockImplementation(() => null);
-    const { getByText, findByTestId, getByLabelText } = render(
-      <ThemeProvider theme={theme as MyTheme}>
-        <AddProjectsModal
-          closeModal={() => {}}
-          onProjectSubmission={() => {}}
-          isOpen
-        />
-      </ThemeProvider>
-    );
-
+    const { getByLabelText, getByText } = renderModal();
     fireEvent.change(getByLabelText("Project Name"), {
-      target: { value: "Test Project" },
+      target: { value: "Project Name" },
     });
     fireEvent.change(getByLabelText("Description"), {
-      target: { value: "Test Description" },
+      target: { value: "Project Description" },
     });
     fireEvent.change(getByLabelText("Link"), {
-      target: { value: "https://test.com" },
-    });
-    const submitButton = getByText("Save");
-    act(() => {
-      fireEvent.click(submitButton);
+      target: { value: "https://project.com" },
     });
 
-    await waitFor(async () => {
-      const errorMessage = await findByTestId("error-message");
-      expect(errorMessage).toHaveTextContent("Please login to add a project");
+    fireEvent.click(getByText("Save"));
+
+    await waitFor(() => expect(createProject).toHaveBeenCalled());
+    expect(onProjectSubmission).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "1" }),
+      false
+    );
+  });
+
+  it("edits a project when projectToEdit is provided", async () => {
+    (editProject as jest.Mock).mockResolvedValue({
+      id: "2",
+      name: "Updated Project",
+      description: "Updated Description",
+      image: "image",
+      link: "https://updated.com",
     });
-    mockLocalStorage.mockRestore();
+
+    const projectToEdit = {
+      _id: "2",
+      name: "Old Project",
+      description: "Old Description",
+      image: "old",
+      link: "https://old.com",
+    };
+
+    const { getByText } = renderModal({ projectToEdit });
+
+    userEvent.click(getByText("Save"));
+
+    await waitFor(() => expect(editProject).toHaveBeenCalledWith("2", expect.any(FormData)));
+    expect(onProjectSubmission).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "2" }),
+      true
+    );
+  });
+
+  it("clears the session on unauthorized response", async () => {
+    (createProject as jest.Mock).mockRejectedValue({
+      response: { status: 401 },
+      isAxiosError: true,
+    });
+
+    const { getByText } = renderModal();
+
+    fireEvent.click(getByText("Save"));
+
+    await waitFor(() => {
+      expect(clearSession).toHaveBeenCalled();
+    });
   });
 });

--- a/src/frontend/components/Modal/AddProjectsModal.tsx
+++ b/src/frontend/components/Modal/AddProjectsModal.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import React, { useEffect, useRef, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import { getModalStyles } from "./Modal.style";
 import { useTheme } from "../../../hooks/useTheme";
 import { Project } from "../UserDashboard/UserDashboard";
@@ -7,6 +7,9 @@ import TextArea from "../TextArea/TextArea";
 import Button from "../Button/Button";
 import { createProject, editProject } from "../../../api";
 import LoadingBars from "../LoadingBars/LoadingBars";
+import { UserContext, UserContextProps } from "../../../UserContext";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
 
 interface AddProjectsModalProps {
   closeModal: () => void;
@@ -25,7 +28,6 @@ interface AddProjectsModalProps {
 }
 
 const initialFormState = {
-  userId: localStorage.getItem("userId"),
   name: "",
   description: "",
   link: "",
@@ -40,9 +42,10 @@ const AddProjectsModal: React.FC<AddProjectsModalProps> = ({
 }) => {
   const theme = useTheme();
   const style = getModalStyles(theme);
+  const { clearSession } = useContext(UserContext) as UserContextProps;
+  const navigate = useNavigate();
 
   type FormState = {
-    userId: string | null;
     name: string;
     description: string;
     link: string;
@@ -57,7 +60,6 @@ const AddProjectsModal: React.FC<AddProjectsModalProps> = ({
   useEffect(() => {
     if (projectToEdit) {
       setFormState({
-        userId: localStorage.getItem("userId"),
         name: projectToEdit.name,
         description: projectToEdit.description,
         link: projectToEdit.link,
@@ -82,36 +84,40 @@ const AddProjectsModal: React.FC<AddProjectsModalProps> = ({
   ) => {
     e.preventDefault();
     if (!validateForm()) return;
-    const userId = localStorage.getItem("userId");
-
-    if (!userId) {
-      setErrorMessage("Please login to add a project");
-      return;
-    }
-
     const formData = new FormData();
-    Object.keys(formState).forEach((key) => {
-      const formKey = key as keyof typeof formState;
-      const value = formState[formKey] || "";
-      formData.append(formKey, value);
-    });
+    formData.append("name", formState.name);
+    formData.append("description", formState.description);
+    formData.append("link", formState.link);
+    if (formState.image) {
+      formData.append("image", formState.image);
+    }
     setIsLoading(true);
     try {
       const isEdit = !!projectToEdit?._id;
       const response = await (isEdit
-        ? editProject(userId, projectToEdit?._id, formData)
+        ? editProject(projectToEdit?._id, formData)
         : createProject(formData));
-      onProjectSubmission(
-        { ...response, _id: response._id || response.id },
-        isEdit
-      );
+      const projectId = response.id || response._id || projectToEdit?._id;
+      const normalizedProject = {
+        id: projectId,
+        _id: projectId,
+        name: response.name,
+        description: response.description,
+        image: response.image,
+        link: response.link,
+      };
+      onProjectSubmission(normalizedProject, isEdit);
       closeModal();
       setFormState(initialFormState);
       if (fileInputRef.current) {
         fileInputRef.current.value = "";
       }
     } catch (error: any) {
-      if (error.response) {
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        setErrorMessage("Session expired. Please log in again.");
+        clearSession();
+        navigate("/login");
+      } else if (error.response) {
         // Server responded with a status other than 2xx
         setErrorMessage(`Server error: ${error.response.data.message}`);
       } else if (error.request) {

--- a/src/frontend/components/Modal/AddSkillsModal.test.tsx
+++ b/src/frontend/components/Modal/AddSkillsModal.test.tsx
@@ -3,123 +3,114 @@ import "@testing-library/jest-dom";
 import {
   render,
   screen,
-  getByText,
   fireEvent,
-  act,
   waitFor,
-  getByRole,
-  findByText,
 } from "@testing-library/react";
 import AddSkillsModal from "./AddSkillsModal";
 import { ThemeProvider } from "@emotion/react";
 import { theme, MyTheme } from "../../../theme";
-import * as api from "../../../api";
-import { OptionType } from "../../../skills/skills";
 import userEvent from "@testing-library/user-event";
+import { UserContext, UserContextProps } from "../../../UserContext";
+import { updateSkills } from "../../../api";
+import { MemoryRouter } from "react-router-dom";
 
-jest.mock("axios", () => ({
-  get: jest.fn(),
-  post: jest.fn(),
+jest.mock("../../../api", () => ({
+  updateSkills: jest.fn(),
 }));
-const addSkillsMock = jest
-  .spyOn(api, "addSkills")
-  .mockImplementation((skills) => {
-    const token = localStorage.getItem("portfolioToken");
-    if (!token) {
-      throw new Error("No userId found");
-    }
-    return Promise.resolve();
-  });
-const onAddSkills = jest.fn();
+
 const closeModal = jest.fn();
+const onAddSkills = jest.fn();
+
+const renderModal = (contextOverrides: Partial<UserContextProps> = {}) => {
+  const contextValue = {
+    user: null,
+    setUser: jest.fn(),
+    portfolioToken: null,
+    setPortfolioToken: jest.fn(),
+    refreshUser: jest.fn(),
+    clearSession: jest.fn(),
+    loading: false,
+    ...contextOverrides,
+  } as UserContextProps;
+
+  return render(
+    <MemoryRouter>
+      <ThemeProvider theme={theme as MyTheme}>
+        <UserContext.Provider value={contextValue}>
+          <AddSkillsModal
+            closeModal={closeModal}
+            onAddSkills={onAddSkills}
+            currentTechSkills={[]}
+            currentSoftSkills={[]}
+          />
+        </UserContext.Provider>
+      </ThemeProvider>
+    </MemoryRouter>
+  );
+};
 
 describe("AddSkillsModal", () => {
   beforeEach(() => {
-    localStorage.setItem("portfolioToken", "1");
-  });
-  afterEach(() => {
-    localStorage.removeItem("portfolioToken");
     jest.clearAllMocks();
   });
-  it("calls the correct functions with the correct arguments when adding skills", async () => {
-    render(
-      <ThemeProvider theme={theme as MyTheme}>
-        <AddSkillsModal
-          closeModal={closeModal}
-          onAddSkills={onAddSkills}
-          currentTechSkills={[
-            { value: "React", label: "React" },
-            { value: "Node.js", label: "Node.js" },
-          ]}
-          currentSoftSkills={[
-            { value: "Communication", label: "Communication" },
-            { value: "Problem solving", label: "Problem solving" },
-          ]}
-        />
-      </ThemeProvider>
-    );
-    const addSkillsButton = screen.getByText("Save");
-    fireEvent.click(addSkillsButton);
-    await waitFor(() => expect(addSkillsMock).toHaveBeenCalledTimes(1));
-  });
-  it("throws an error when no userId is found", async () => {
-    localStorage.removeItem("portfolioToken");
-    render(
-      <ThemeProvider theme={theme as MyTheme}>
-        <AddSkillsModal
-          closeModal={closeModal}
-          onAddSkills={onAddSkills}
-          currentTechSkills={[
-            { value: "React", label: "React" },
-            { value: "Node.js", label: "Node.js" },
-          ]}
-          currentSoftSkills={[
-            { value: "Communication", label: "Communication" },
-            { value: "Problem solving", label: "Problem solving" },
-          ]}
-        />
-      </ThemeProvider>
-    );
-    const addSkillsButton = screen.getByText("Save");
-    fireEvent.click(addSkillsButton);
-    await waitFor(() => expect(addSkillsMock).toHaveBeenCalledTimes(0));
-  });
-  it("handlesSkills updates tech skills correctly", async () => {
-    const currentTechSkills: OptionType[] = [];
-    const currentSoftSkills: OptionType[] = [];
 
-    const { getByRole, getByText } = render(
-      <ThemeProvider theme={theme as MyTheme}>
-        <AddSkillsModal
-          closeModal={closeModal}
-          onAddSkills={onAddSkills}
-          currentTechSkills={currentTechSkills}
-          currentSoftSkills={currentSoftSkills}
-        />
-      </ThemeProvider>
-    );
-
-    const techSkillsSelect = getByRole("combobox", {
-      name: "Technical Skills",
+  it("calls updateSkills and onAddSkills with API response", async () => {
+    (updateSkills as jest.Mock).mockResolvedValue({
+      techSkills: ["React"],
+      softSkills: ["Teamwork"],
     });
-    userEvent.click(techSkillsSelect);
+    renderModal();
 
-    userEvent.type(techSkillsSelect, "JavaScript{enter}");
-
-    await waitFor(() =>
-      expect((techSkillsSelect as HTMLInputElement).value).toBe("JavaScript")
-    );
-
-    const saveButton = getByText("Save");
-    userEvent.click(saveButton);
+    fireEvent.click(screen.getByText("Save"));
 
     await waitFor(() => {
-      expect(onAddSkills).toHaveBeenCalledWith(
-        expect.objectContaining({
-          techSkills: expect.arrayContaining(["JavaScript"]),
-          softSkills: expect.arrayContaining([]),
-        })
-      );
+      expect(updateSkills).toHaveBeenCalledWith({
+        techSkills: [],
+        softSkills: [],
+      });
+      expect(onAddSkills).toHaveBeenCalledWith({
+        techSkills: ["React"],
+        softSkills: ["Teamwork"],
+      });
+    });
+  });
+
+  it("updates selected tech skills", async () => {
+    (updateSkills as jest.Mock).mockResolvedValue({
+      techSkills: ["JavaScript"],
+      softSkills: [],
+    });
+    renderModal();
+
+    const techSkillsSelect = screen.getByRole("combobox", {
+      name: "Technical Skills",
+    });
+    await userEvent.click(techSkillsSelect);
+    await userEvent.type(techSkillsSelect, "JavaScript{enter}");
+
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(updateSkills).toHaveBeenCalledWith({
+        techSkills: ["JavaScript"],
+        softSkills: [],
+      });
+    });
+  });
+
+  it("clears the session on unauthorized error", async () => {
+    const clearSession = jest.fn();
+    (updateSkills as jest.Mock).mockRejectedValue({
+      response: { status: 401 },
+      isAxiosError: true,
+    });
+
+    renderModal({ clearSession });
+
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(clearSession).toHaveBeenCalled();
     });
   });
 });

--- a/src/frontend/components/Modal/AddSkillsModal.tsx
+++ b/src/frontend/components/Modal/AddSkillsModal.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { ActionMeta, OnChangeValue } from "react-select";
 import { softSkills } from "../../../skills/skills";
 import { techSkills } from "../../../skills/skills";
@@ -9,7 +9,10 @@ import { getModalStyles } from "./Modal.style";
 import { useTheme } from "../../../hooks/useTheme";
 import { Skills } from "../UserDashboard/UserDashboard";
 import Button from "../Button/Button";
-import { addSkills } from "../../../api";
+import { updateSkills } from "../../../api";
+import { UserContext, UserContextProps } from "../../../UserContext";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
 
 interface AddSkillsModalProps {
   closeModal: () => void;
@@ -31,6 +34,8 @@ const AddSkillsModal: React.FC<AddSkillsModalProps> = ({
 
   const theme = useTheme();
   const style = getModalStyles(theme);
+  const { clearSession } = useContext(UserContext) as UserContextProps;
+  const navigate = useNavigate();
   useEffect(() => {
     setSelectedTechSkills(currentTechSkills);
     setSelectedSoftSkills(currentSoftSkills);
@@ -56,16 +61,18 @@ const AddSkillsModal: React.FC<AddSkillsModalProps> = ({
       softSkills: selectedSoftSkills.map((skill) => skill.value),
     };
 
-    const portfolioToken = localStorage.getItem("portfolioToken");
-    if (portfolioToken) {
-      try {
-        await addSkills(portfolioToken, skills);
-        onAddSkills(skills);
-      } catch (error) {
+    try {
+      const updatedSkills = await updateSkills(skills);
+      onAddSkills(updatedSkills);
+      closeModal();
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        clearSession();
+        navigate("/login");
+      } else {
         console.error("An error occurred while trying to add skills", error);
       }
     }
-    closeModal();
   };
 
   return (

--- a/src/frontend/components/Modal/EditUserDetails.test.tsx
+++ b/src/frontend/components/Modal/EditUserDetails.test.tsx
@@ -5,60 +5,50 @@ import { theme, MyTheme } from "../../../theme";
 import EditUserDetails from "./EditUserDetails";
 import { render, fireEvent, waitFor } from "@testing-library/react";
 import { editUserDetails } from "../../../api";
-import { UserContext } from "../../../UserContext";
-
-jest.mock("axios", () => ({
-  get: jest.fn(),
-  post: jest.fn(),
-  put: jest.fn(),
-}));
+import { UserContext, UserContextProps } from "../../../UserContext";
 
 jest.mock("../../../api", () => ({
   editUserDetails: jest.fn(),
 }));
 
 describe("Edit User Details Modal", () => {
-  let localStorageMock: { [key: string]: string };
   const mockSetUser = jest.fn();
+  const closeModal = jest.fn();
   const user = {
-    _id: "1",
+    id: "1",
     fullName: "John Doe",
     email: "test@email.com",
     jobTitle: "Software Developer",
-    password: "password",
     profileImage: "profileImage",
   };
 
-  beforeEach(() => {
-    localStorageMock = {};
-    global.localStorage = {
-      getItem: jest.fn((key) => localStorageMock[key]),
-      setItem: jest.fn((key, value) => {
-        localStorageMock[key] = value;
-      }),
-      clear: jest.fn(() => {
-        localStorageMock = {};
-      }),
-      removeItem: jest.fn((key) => {
-        delete localStorageMock[key];
-      }),
-      length: 0,
-      key: jest.fn(),
-    };
-    localStorageMock.userId = "1";
-    localStorageMock.portfolioToken = "token";
-    global.localStorage.setItem("userId", "1");
-    global.localStorage.setItem("portfolioToken", "token");
-  });
+  const renderModal = (contextOverrides: Partial<UserContextProps> = {}) => {
+    const contextValue = {
+      user,
+      setUser: mockSetUser,
+      portfolioToken: "mockToken",
+      setPortfolioToken: jest.fn(),
+      refreshUser: jest.fn(),
+      clearSession: jest.fn(),
+      loading: false,
+      ...contextOverrides,
+    } as UserContextProps;
 
-  it("should render the edit user details modal", () => {
-    const { getByText, getByLabelText } = render(
-      <UserContext.Provider value={{ user, setUser: mockSetUser }}>
-        <ThemeProvider theme={theme}>
-          <EditUserDetails closeModal={() => {}} />
+    return render(
+      <UserContext.Provider value={contextValue}>
+        <ThemeProvider theme={theme as MyTheme}>
+          <EditUserDetails closeModal={closeModal} />
         </ThemeProvider>
       </UserContext.Provider>
     );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should render the edit user details modal", () => {
+    const { getByText, getByLabelText } = renderModal();
 
     expect(getByText("Edit User Details")).toBeInTheDocument();
     expect(getByLabelText("Name")).toBeInTheDocument();
@@ -67,13 +57,7 @@ describe("Edit User Details Modal", () => {
   });
 
   it("should populate the form with the user details", () => {
-    const { getByDisplayValue } = render(
-      <UserContext.Provider value={{ user, setUser: mockSetUser }}>
-        <ThemeProvider theme={theme}>
-          <EditUserDetails closeModal={() => {}} />
-        </ThemeProvider>
-      </UserContext.Provider>
-    );
+    const { getByDisplayValue } = renderModal();
 
     expect(getByDisplayValue("John Doe")).toBeInTheDocument();
     expect(getByDisplayValue("test@email.com")).toBeInTheDocument();
@@ -81,16 +65,16 @@ describe("Edit User Details Modal", () => {
   });
 
   it("should handle user input and save the details", async () => {
-    (editUserDetails as jest.Mock).mockResolvedValueOnce({});
-    const closeModal = jest.fn();
+    (editUserDetails as jest.Mock).mockResolvedValueOnce({
+      user: {
+        ...user,
+        fullName: "Jane Doe",
+        email: "jane@email.com",
+        jobTitle: "Senior Developer",
+      },
+    });
 
-    const { getByLabelText, getByText } = render(
-      <UserContext.Provider value={{ user, setUser: mockSetUser }}>
-        <ThemeProvider theme={theme}>
-          <EditUserDetails closeModal={closeModal} />
-        </ThemeProvider>
-      </UserContext.Provider>
-    );
+    const { getByLabelText, getByText } = renderModal();
 
     fireEvent.change(getByLabelText("Name"), { target: { value: "Jane Doe" } });
     fireEvent.change(getByLabelText("Email"), {
@@ -104,15 +88,11 @@ describe("Edit User Details Modal", () => {
 
     await waitFor(() => expect(editUserDetails).toHaveBeenCalled());
 
-    expect(editUserDetails).toHaveBeenCalledWith(
-      "token",
-      {
-        fullName: "Jane Doe",
-        email: "jane@email.com",
-        jobTitle: "Senior Developer",
-      },
-      "1"
-    );
+    expect(editUserDetails).toHaveBeenCalledWith({
+      fullName: "Jane Doe",
+      email: "jane@email.com",
+      jobTitle: "Senior Developer",
+    });
 
     expect(mockSetUser).toHaveBeenCalledWith({
       ...user,
@@ -128,15 +108,8 @@ describe("Edit User Details Modal", () => {
     (editUserDetails as jest.Mock).mockImplementation(
       () => new Promise((resolve) => setTimeout(resolve, 100))
     );
-    const closeModal = jest.fn();
 
-    const { getByText, getByRole } = render(
-      <UserContext.Provider value={{ user, setUser: mockSetUser }}>
-        <ThemeProvider theme={theme}>
-          <EditUserDetails closeModal={closeModal} />
-        </ThemeProvider>
-      </UserContext.Provider>
-    );
+    const { getByText, getByRole } = renderModal();
 
     fireEvent.click(getByText("Save"));
 

--- a/src/frontend/components/Modal/EditUserDetails.tsx
+++ b/src/frontend/components/Modal/EditUserDetails.tsx
@@ -6,11 +6,15 @@ import { editUserDetails } from "../../../api";
 import { getModalStyles } from "./Modal.style";
 import { useTheme } from "../../../hooks/useTheme";
 import LoadingBars from "../LoadingBars/LoadingBars";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
 
 const EditUserDetails: React.FC<{ closeModal: () => void }> = ({
   closeModal,
 }) => {
-  const { user, setUser } = useContext(UserContext) as UserContextProps;
+  const { user, setUser, clearSession } =
+    useContext(UserContext) as UserContextProps;
+  const navigate = useNavigate();
 
   const [fullName, setFullName] = useState(user?.fullName || "");
   const [email, setEmail] = useState(user?.email || "");
@@ -39,20 +43,27 @@ const EditUserDetails: React.FC<{ closeModal: () => void }> = ({
           jobTitle,
         };
 
-        const portfolioToken = localStorage.getItem("portfolioToken") || "";
-        const userId = localStorage.getItem("userId") || "";
-        await editUserDetails(portfolioToken, formData, userId);
+        const response = await editUserDetails(formData);
 
-        setUser({
-          ...user,
-          fullName,
-          email,
-          jobTitle,
-        });
-        setLoading(false);
+        if (response.user) {
+          setUser(response.user);
+        } else {
+          setUser({
+            ...user,
+            fullName,
+            email,
+            jobTitle,
+          });
+        }
       }
     } catch (error) {
-      console.error("Error editing user details", error);
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        clearSession();
+        navigate("/login");
+      } else {
+        console.error("Error editing user details", error);
+      }
+    } finally {
       setLoading(false);
     }
     closeModal();

--- a/src/frontend/components/Register/Register.test.tsx
+++ b/src/frontend/components/Register/Register.test.tsx
@@ -5,23 +5,38 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ThemeProvider } from "@emotion/react";
 import Register from "./Register";
 import { theme, MyTheme } from "../../../theme";
-import { UserContext } from "../../../UserContext";
+import { UserContext, UserContextProps } from "../../../UserContext";
 import { MemoryRouter } from "react-router-dom";
 import { registerUser } from "../../../api";
 
-jest.mock("axios", () => ({
-  get: jest.fn(),
-  post: jest.fn(),
-}));
 jest.mock("../../../api", () => ({
-  registerUser: jest.fn(() => Promise.resolve({ status: 200, data: {} })),
+  registerUser: jest.fn(() =>
+    Promise.resolve({
+      user: { id: "1" },
+      portfolioToken: "token",
+    })
+  ),
 }));
 
+const defaultContextValue: UserContextProps = {
+  user: null,
+  setUser: jest.fn(),
+  portfolioToken: null,
+  setPortfolioToken: jest.fn(),
+  refreshUser: jest.fn(),
+  clearSession: jest.fn(),
+  loading: false,
+};
+
 describe("Register component", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("renders a form", async () => {
     render(
       <MemoryRouter>
-        <UserContext.Provider value={{ user: null, setUser: jest.fn() }}>
+        <UserContext.Provider value={defaultContextValue}>
           <ThemeProvider theme={theme as MyTheme}>
             <Register />
           </ThemeProvider>
@@ -31,11 +46,12 @@ describe("Register component", () => {
     const form = await screen.findByTestId("register-form");
     expect(form).toBeInTheDocument();
   });
+
   it("renders Register form and handles submit", async () => {
     const mockSubmit = jest.fn();
     const { getByTestId, getByLabelText } = render(
       <MemoryRouter>
-        <UserContext.Provider value={{ user: null, setUser: jest.fn() }}>
+        <UserContext.Provider value={defaultContextValue}>
           <ThemeProvider theme={theme as MyTheme}>
             <Register onSubmit={mockSubmit} />
           </ThemeProvider>
@@ -61,6 +77,7 @@ describe("Register component", () => {
     fireEvent.submit(form);
     await waitFor(() => expect(registerUser).toHaveBeenCalledTimes(1));
   });
+
   it("alerts the user if the user is already registered", async () => {
     (registerUser as jest.Mock).mockImplementationOnce(() =>
       Promise.reject({
@@ -70,7 +87,7 @@ describe("Register component", () => {
     );
     const { getByTestId, getByLabelText } = render(
       <MemoryRouter>
-        <UserContext.Provider value={{ user: null, setUser: jest.fn() }}>
+        <UserContext.Provider value={defaultContextValue}>
           <ThemeProvider theme={theme as MyTheme}>
             <Register />
           </ThemeProvider>
@@ -101,11 +118,11 @@ describe("Register component", () => {
       "User already registered!"
     );
   });
+
   it("form doesnt submit if a required field is missing", async () => {
-    const mockRegister = jest.fn();
     const { getByTestId } = render(
       <MemoryRouter>
-        <UserContext.Provider value={{ user: null, setUser: jest.fn() }}>
+        <UserContext.Provider value={defaultContextValue}>
           <ThemeProvider theme={theme as MyTheme}>
             <Register />
           </ThemeProvider>
@@ -124,6 +141,6 @@ describe("Register component", () => {
 
     fireEvent.click(submitButton);
 
-    expect(mockRegister).not.toHaveBeenCalled();
+    expect(registerUser).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/frontend/components/Register/Register.tsx
+++ b/src/frontend/components/Register/Register.tsx
@@ -14,7 +14,8 @@ type RegisterProps = {
 };
 
 const Register: React.FC<RegisterProps> = () => {
-  const { setUser } = useContext(UserContext) as UserContextProps;
+  const { setUser, setPortfolioToken } =
+    useContext(UserContext) as UserContextProps;
   const navigate = useNavigate();
   const [error, setError] = useState("");
   const [fieldErrors, setFieldErrors] = useState({
@@ -96,13 +97,13 @@ const Register: React.FC<RegisterProps> = () => {
         formData.append("profileImage", profileImage.files[0]);
       }
       try {
-        const response = await registerUser(formData);
+        const data = await registerUser(formData);
 
-        if (response.status === 201 || response.status === 200) {
-          setUser(response.data);
-          navigate("/login");
-        } else if (response.status === 400) {
-          setError("User already registered!");
+        if (data.user) {
+          setUser(data.user);
+          setPortfolioToken(data.portfolioToken ?? null);
+          setError("");
+          navigate("/userdashboard");
         }
       } catch (err) {
         if (isAxiosError(err) && err.response) {

--- a/src/frontend/components/UserDashboard/UserDashboard.test.tsx
+++ b/src/frontend/components/UserDashboard/UserDashboard.test.tsx
@@ -8,22 +8,18 @@ import { fetchProjects, fetchSkills } from "../../../api";
 import { ThemeProvider } from "@emotion/react";
 import { MyTheme, theme } from "../../../theme";
 import { ThemeContext } from "@emotion/react";
-import axios from "axios";
 
-jest.mock("axios", () => ({
-  get: jest.fn(),
-  post: jest.fn(),
-  put: jest.fn(),
-  delete: jest.fn(),
-}));
 jest.mock("../../../api", () => ({
   fetchProjects: jest.fn(),
   fetchSkills: jest.fn(),
+  deleteProject: jest.fn(),
+  updateSkills: jest.fn(),
 }));
 
 const mockSetUser = jest.fn((user: User | null) => {}) as React.Dispatch<
   React.SetStateAction<User | null>
 >;
+const mockSetPortfolioToken = jest.fn();
 const mockProjects = [
   {
     _id: "1",
@@ -47,18 +43,21 @@ const mockSkills = {
 };
 
 const mockUser = {
-  _id: "1",
+  id: "1",
   fullName: "John Doe",
   email: "john.doe@example.com",
   jobTitle: "Software Engineer",
   profileImage: "avatar.png",
-  password: "password",
-  portfolioToken: "mockToken",
 };
 
 const mockUserContextValue: UserContextProps = {
   user: mockUser,
   setUser: mockSetUser,
+  portfolioToken: "mockToken",
+  setPortfolioToken: mockSetPortfolioToken,
+  refreshUser: jest.fn(),
+  clearSession: jest.fn(),
+  loading: false,
 };
 
 const mockContext = {
@@ -69,16 +68,11 @@ const mockContext = {
 describe("UserDashboard", () => {
   beforeEach(() => {
     process.env.REACT_APP_API_URL = "http://localhost:3001";
-    localStorage.setItem("portfolioToken", mockUser.portfolioToken);
     (fetchProjects as jest.Mock).mockResolvedValue(mockProjects);
     (fetchSkills as jest.Mock).mockResolvedValue(mockSkills);
-    (axios.get as jest.Mock).mockResolvedValue({
-      data: { user: mockUser },
-    });
   });
 
   afterEach(() => {
-    localStorage.clear();
     jest.resetAllMocks();
   });
 
@@ -98,6 +92,8 @@ describe("UserDashboard", () => {
     });
 
     await waitFor(() => {
+      expect(fetchProjects).toHaveBeenCalled();
+      expect(fetchSkills).toHaveBeenCalled();
       expect(
         screen.getByText(`${mockUser.fullName}'s profile`)
       ).toBeInTheDocument();
@@ -106,18 +102,9 @@ describe("UserDashboard", () => {
         "src",
         `http://localhost:3001/${mockUser.profileImage}`
       );
-      const nameElements = screen.getAllByText("Name");
-      nameElements.forEach((element) => {
-        expect(element).toBeInTheDocument();
-      });
       expect(screen.getByText(mockUser.fullName)).toBeInTheDocument();
-      expect(screen.getByText("Email")).toBeInTheDocument();
       expect(screen.getByText(mockUser.email)).toBeInTheDocument();
-      expect(screen.getByText("Job Title")).toBeInTheDocument();
       expect(screen.getByText(mockUser.jobTitle)).toBeInTheDocument();
-
-      expect(fetchProjects).toHaveBeenCalledWith(mockUser.portfolioToken);
-      expect(fetchSkills).toHaveBeenCalledWith(mockUser.portfolioToken);
       expect(screen.getByText("Project 1")).toBeInTheDocument();
       expect(screen.getByText("Project 2")).toBeInTheDocument();
     });
@@ -139,7 +126,6 @@ describe("UserDashboard", () => {
     });
 
     await waitFor(() => {
-      expect(fetchSkills).toHaveBeenCalledWith(mockUser.portfolioToken);
       expect(screen.getByText("Technical Skills")).toBeInTheDocument();
       expect(screen.getByText("HTML")).toBeInTheDocument();
       expect(screen.getByText("CSS")).toBeInTheDocument();
@@ -150,7 +136,7 @@ describe("UserDashboard", () => {
     });
   });
 
-  it("displays an error message if the API call fails", async () => {
+  it("logs an error if the API call fails", async () => {
     (fetchProjects as jest.Mock).mockRejectedValue(new Error("API error"));
     (fetchSkills as jest.Mock).mockRejectedValue(new Error("API error"));
 
@@ -173,10 +159,7 @@ describe("UserDashboard", () => {
     });
 
     await waitFor(() => {
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "An error occurred while trying to fetch the user data",
-        expect.any(Error)
-      );
+      expect(consoleSpy).toHaveBeenCalled();
     });
     consoleSpy.mockRestore();
   });

--- a/src/frontend/components/UserDashboard/UserDashboard.tsx
+++ b/src/frontend/components/UserDashboard/UserDashboard.tsx
@@ -12,13 +12,17 @@ import Header from "../Header/Header";
 import Button from "../Button/Button";
 import { useNavigate } from "react-router-dom";
 import { useThemeContext } from "../ThemeContext";
-import { fetchProjects, fetchSkills } from "../../../api";
+import {
+  fetchProjects,
+  fetchSkills,
+  deleteProject,
+  updateSkills,
+} from "../../../api";
 import DeleteModal from "../Modal/DeleteModal";
 import axios from "axios";
 import LoadingBars from "../LoadingBars/LoadingBars";
 import EditUserDetails from "../Modal/EditUserDetails";
 import Modal from "../Modal/Modal";
-import { deleteProject } from "../../../api";
 
 export interface Project {
   _id?: string;
@@ -60,7 +64,8 @@ const UserDashboard: React.FC = () => {
   );
   const openButtonRef = useRef<HTMLButtonElement | null>(null);
 
-  const { user, setUser } = useContext(UserContext) as UserContextProps;
+  const { user, portfolioToken, clearSession } =
+    useContext(UserContext) as UserContextProps;
 
   const techSkillsOption = skills.techSkills.map((skill) => ({
     value: skill,
@@ -75,39 +80,41 @@ const UserDashboard: React.FC = () => {
 
   const API_BASE_URL = process.env.REACT_APP_API_URL;
 
-  const fetchUserData = useCallback(
-    async (token: string) => {
-      try {
-        const userResponse = await axios.get(`${API_BASE_URL}/user/${token}`);
-        setUser(userResponse.data.user);
-
-        // Fetch projects
-        setIsLoading(true);
-        const projectsData = await fetchProjects(token);
-        setProjects(projectsData);
-        setIsLoading(false);
-
-        // Fetch skills
-        setIsLoading(true);
-        const skillsData = await fetchSkills(token);
-        setSkills(skillsData);
-        setIsLoading(false);
-      } catch (error) {
+  const loadDashboard = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const [projectsData, skillsData] = await Promise.all([
+        fetchProjects(),
+        fetchSkills(),
+      ]);
+      setProjects(projectsData);
+      setSkills(skillsData);
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        clearSession();
+        navigate("/login");
+      } else {
         console.error(
           "An error occurred while trying to fetch the user data",
           error
         );
       }
-    },
-    [API_BASE_URL, setUser]
-  );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [clearSession, navigate]);
 
   useEffect(() => {
-    const token = localStorage.getItem("portfolioToken");
-    if (token) {
-      fetchUserData(token);
+    if (user) {
+      loadDashboard();
     }
-  }, [fetchUserData]);
+  }, [user, loadDashboard]);
+
+  useEffect(() => {
+    if (!user) {
+      navigate("/login");
+    }
+  }, [user, navigate]);
 
   const handleOpenModal = (
     type: string,
@@ -147,25 +154,29 @@ const UserDashboard: React.FC = () => {
     setIsEditUserModalOpen(true);
   };
   const handleDeleteProject = async () => {
-    const userId = localStorage.getItem("userId");
-    if (!userId || !projectIdToDelete) {
-      alert("Please login to delete a project");
+    if (!projectIdToDelete) {
+      alert("Please select a project to delete");
       return;
     }
 
     setIsLoading(true);
 
     try {
-      await deleteProject(userId, projectIdToDelete);
+      await deleteProject(projectIdToDelete);
       setProjects((prevProjects) =>
         prevProjects.filter((project) => project._id !== projectIdToDelete)
       );
       handleCloseModal();
     } catch (error) {
-      console.error(
-        "An error occurred while trying to delete the project",
-        error
-      );
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        clearSession();
+        navigate("/login");
+      } else {
+        console.error(
+          "An error occurred while trying to delete the project",
+          error
+        );
+      }
     } finally {
       setIsLoading(false);
     }
@@ -209,21 +220,14 @@ const UserDashboard: React.FC = () => {
   }, [projects]);
 
   const handleAddSkills = async (newSkills: Skills) => {
-    setSkills((prevSkills) => ({
-      techSkills: Array.from(
-        new Set([...prevSkills.techSkills, ...newSkills.techSkills])
-      ),
-      softSkills: Array.from(
-        new Set([...prevSkills.softSkills, ...newSkills.softSkills])
-      ),
-    }));
-
-    const portfolioToken = localStorage.getItem("portfolioToken");
-    if (portfolioToken) {
-      try {
-        const updatedSkills = await fetchSkills(portfolioToken);
-        setSkills(updatedSkills);
-      } catch (error) {
+    try {
+      const updatedSkills = await updateSkills(newSkills);
+      setSkills(updatedSkills);
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        clearSession();
+        navigate("/login");
+      } else {
         console.error(
           "An error occurred while trying to get updated skills",
           error
@@ -231,6 +235,10 @@ const UserDashboard: React.FC = () => {
       }
     }
   };
+
+  if (!user) {
+    return null;
+  }
 
   return (
     <div>
@@ -375,11 +383,11 @@ const UserDashboard: React.FC = () => {
                 }}
               ></div>
               <Button
-                onClick={() =>
-                  navigate(
-                    `/portfolio/${localStorage.getItem("portfolioToken")}`
-                  )
-                }
+                onClick={() => {
+                  if (portfolioToken) {
+                    navigate(`/portfolio/${portfolioToken}`);
+                  }
+                }}
                 width={"xlarge"}
                 height={"medium"}
                 borderRadius={"xsmall"}


### PR DESCRIPTION
## Summary
- replace tokenized portfolio auth with short-lived cookie session identifiers and supporting auth endpoints
- update React context, API helpers, and dashboard workflows to rely on httpOnly cookies and handle 401 responses
- document the revised authentication flow, environment variables, and client requirements in the README

## Testing
- npm test *(fails: jest not found because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b97778a8832d95a49ef2246dfbc0